### PR TITLE
Relax active-models gate: PR-AUC tolerance 90% -> 80%

### DIFF
--- a/recession_engine/ensemble_model.py
+++ b/recession_engine/ensemble_model.py
@@ -1907,6 +1907,13 @@ class RecessionEnsembleModel:
 
         This prevents a structurally weak model from diluting stronger supervised
         signals while still keeping a genuine ensemble of at least two models.
+
+        PR-AUC tolerance is 80% of the best CV PR-AUC (was 90%). Loosened
+        after the Chauvet-Piger benchmark joined the ensemble: CP routinely
+        scores PR-AUC ~0.91, which under a 0.90 multiplier set the bar at
+        ~0.82 and made random_forest's membership stochastic across CV
+        re-runs (sometimes 0.78, sometimes 0.83). 0.80 keeps the quality
+        bar tight while making the active set robust to that variance.
         """
         if not cv_scores:
             return []
@@ -1918,7 +1925,7 @@ class RecessionEnsembleModel:
         active = [
             name for name, score in cv_scores.items()
             if score.get('auc', 0.5) >= best_auc - 0.10
-            and score.get('pr_auc', 0.0) >= best_pr_auc * 0.90
+            and score.get('pr_auc', 0.0) >= best_pr_auc * 0.80
             and score.get('brier', 0.25) <= best_brier * 2.00
         ]
 


### PR DESCRIPTION
## Summary

One-line tweak in `_select_active_models` ([recession_engine/ensemble_model.py:1921](../blob/feat/relax-active-models-gate/recession_engine/ensemble_model.py#L1921)) that lowers the relative PR-AUC tolerance from `0.90 * best_pr_auc` to `0.80 * best_pr_auc`.

## Why

After the Chauvet-Piger fix raised the best-model PR-AUC ceiling to ~0.91, the 0.90 multiplier set the qualification bar at ~0.82. Random Forest's CV PR-AUC sits in the 0.78–0.83 band depending on which CV folds and which features get selected — so its membership in the deployed ensemble was effectively a coin flip on every retrain. Variant validation last week: RF at 0.776 (gated). Production refresh today: RF at 0.828 (active).

0.80 puts the threshold at ~0.73, giving RF a structural ~0.05 margin instead of stochastic 0.01.

## What changes today

| Model | CV PR-AUC | Old threshold (0.82) | New threshold (0.73) |
|---|---|---|---|
| chauvet_piger_benchmark | 0.907 | ✓ | ✓ |
| probit | 0.884 | ✓ | ✓ |
| random_forest | 0.828 | ✓ (by 0.012) | ✓ (by 0.105) |
| xgboost | 0.690 | ✗ | ✗ (close — by 0.036) |
| markov_switching | 0.478 | ✗ | ✗ |
| hamilton_benchmark | 0.411 | ✗ | ✗ |
| wright_probit | 0.388 | ✗ | ✗ |

**Active set unchanged** today: probit + RF + chauvet_piger_benchmark.

XGBoost is now within striking distance — if a future retrain lands its CV PR-AUC above 0.73, it joins the ensemble. That's intended: XGB lost some PR-AUC when the recent upgrade dropped PCA from tree input, but it's still doing real work and should be re-admitted once it earns it back.

## Test plan

- [x] All 43 tests pass (`pytest tests/ --ignore=tests/test_loro.py`)
- [x] `_select_active_models` smoke test against current production CV scores returns {probit, RF, chauvet_piger_benchmark}
- [ ] Optional: re-run `python3 -m scheduler.update_job` after merge — expected to be a no-op on the deployed model set since today's CV qualifies the same models under both gates

## Risks

- If the next retrain's CV unexpectedly puts a weak model into the [0.73, 0.82] band, it would now qualify when it wouldn't have before. The other gate criteria (AUC ≥ best - 0.10, Brier ≤ 2 × best) provide a backstop.
- Easy revert: change `0.80` back to `0.90` and re-fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)